### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
 
+
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref_name }}
   cancel-in-progress: true


### PR DESCRIPTION
Hardens 1 workflow(s) in this repo by declaring a workflow-level `permissions: contents: read`. Today those workflows inherit the legacy broad read-write GITHUB_TOKEN; the read-only default reduces blast radius if any step is compromised.

I checked each file - they read the checkout and run tests/lints; no GitHub API writes (no `gh pr/issue`, no `git push`, no release/publish/comment actions). So behavior is unchanged.

Reference: the tj-actions/changed-files compromise (CVE-2025-30066) is the canonical reason to apply least-privilege defaults.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Security-hardening only; jobs already only read the repo and run local checks, with no GitHub API writes.
> 
> **Overview**
> Adds workflow-level **`permissions: contents: read`** to the CI workflow so `GITHUB_TOKEN` is read-only instead of inheriting the default broad write scope.
> 
> Lint, typecheck, and test jobs are unchanged—they still checkout, install with Bun, and run ESLint, `tsc`, and Vitest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f708aaf349516568c82bbc723533b25f485919b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->