### PR TITLE
↪️ fix: Follow IdP end-session Redirect on Admin Sign Out

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -61,7 +61,11 @@ export function Sidebar({ user, collapsed, onToggle }: t.SidebarProps) {
   const handleLogout = async () => {
     setIsLoggingOut(true);
     try {
-      await adminLogoutFn();
+      const result = await adminLogoutFn();
+      if (!result.error && result.redirect) {
+        window.location.href = result.redirect;
+        return;
+      }
       await router.invalidate();
       router.navigate({ to: '/login', search: { redirect: '/' } });
     } catch (error) {

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -287,17 +287,24 @@ export const requireAuthFn = createServerFn({ method: 'GET' })
     };
   });
 
+const logoutResponseSchema = z.object({ redirect: z.string().optional() });
+
 export const adminLogoutFn = createServerFn({ method: 'POST' }).handler(async () => {
   try {
     const session = await useAppSession();
     const token = session.data.token;
 
+    let redirect: string | undefined;
     if (token) {
       try {
-        await fetch(`${getServerApiUrl()}/api/auth/logout`, {
+        const response = await fetch(`${getServerApiUrl()}/api/auth/logout`, {
           method: 'POST',
           headers: { Authorization: `Bearer ${token}` },
         });
+        const parsed = logoutResponseSchema.safeParse(await response.json().catch(() => ({})));
+        if (parsed.success) {
+          redirect = parsed.data.redirect;
+        }
       } catch {
         // Ignore remote logout errors
       }
@@ -305,7 +312,7 @@ export const adminLogoutFn = createServerFn({ method: 'POST' }).handler(async ()
 
     await clearSession(session);
 
-    return { error: false };
+    return { error: false, redirect };
   } catch (error) {
     console.error('Admin logout error:', error);
     return { error: true, message: 'Logout failed' };


### PR DESCRIPTION
## Problem

Fixes #68.

When the admin panel runs with `ADMIN_SSO_ONLY=true` against an OpenID provider using RP-initiated logout (`OPENID_USE_END_SESSION_ENDPOINT=true` on the LibreChat server), the **Sign out** button never actually signs you out. It clears the local session, returns to `/login`, and the page auto-redirects back to the IdP — which still has a live session — silently re-authenticating the **same** account. The user can never sign out or switch accounts.

## Root cause

`adminLogoutFn` (`src/server/auth.ts`) POSTs to LibreChat's `/api/auth/logout` but ignores the response body. With `OPENID_USE_END_SESSION_ENDPOINT=true`, that endpoint returns the IdP `end_session` URL in `{ redirect }`. Discarding it means only the local cookie is cleared and the IdP session survives.

LibreChat's own web client handles this correctly: its `AuthContext` logout handler reads `data.redirect` and follows it via `window.location`. This PR mirrors that behaviour in the admin panel.

## Change

- `adminLogoutFn`: parse the logout response and surface `redirect`.
- `Sidebar.handleLogout`: when `redirect` is present, follow it via `window.location`; otherwise fall back to the existing `/login` navigation.

The response is parsed with a small zod schema (consistent with the existing `refreshResponseSchema` pattern in the same file) and the remote logout call stays wrapped in try/catch, so a failed/absent logout response still clears the local session as before.

## Verification

- `tsc --noEmit` clean.
- `eslint src/server/auth.ts src/components/Sidebar.tsx --max-warnings 0` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the logout path for SSO/OpenID deployments; behavior is gated on an optional redirect with the same local-session fallback as before.
> 
> **Overview**
> **Sign out** now completes RP-initiated OpenID logout when the backend returns an IdP end-session URL.
> 
> `adminLogoutFn` parses the LibreChat `/api/auth/logout` JSON (optional `redirect` via zod) and returns it after clearing the local session. **Sidebar** `handleLogout` navigates with `window.location.href` when that URL is present; otherwise it keeps the existing invalidate + `/login` flow. Remote logout failures still only clear the admin cookie, unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 558f4c331519174a87bafd95b5cdacb4013fbd3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->