### PR TITLE
🪒 feat: Tighten Read-Only UX in Disabled Config Sections

### DIFF
--- a/src/components/configuration/ConfigRow.tsx
+++ b/src/components/configuration/ConfigRow.tsx
@@ -80,7 +80,6 @@ export function ConfigRow({
       className={cn(
         'config-row flex w-full gap-6 rounded-md px-2.5 py-2 transition-opacity',
         hasSubContent ? 'items-start' : 'items-center',
-        disabled && 'pointer-events-none',
         isPendingReset && 'opacity-50',
         !isPendingReset && !isConfigured && !isTouched && 'opacity-50',
       )}

--- a/src/components/configuration/FieldRenderer.tsx
+++ b/src/components/configuration/FieldRenderer.tsx
@@ -606,7 +606,10 @@ export function NestedGroup({
         className={cn(depth > 0 ? 'mt-3' : 'mt-4', 'flex flex-col')}
         style={indent ? { paddingLeft: indent } : undefined}
       >
-        <div className="flex items-center gap-2 border-b border-(--cui-color-stroke-default) py-2 pl-1">
+        <div
+          data-section-id={sectionId}
+          className="flex items-center gap-2 border-b border-(--cui-color-stroke-default) py-2 pl-1"
+        >
           <span className="text-sm font-medium text-(--cui-color-text-default)">{label}</span>
           {totalCount > 0 && (
             <span

--- a/src/components/configuration/FieldRenderer.tsx
+++ b/src/components/configuration/FieldRenderer.tsx
@@ -93,6 +93,7 @@ function ArrayObjectNestedGroup({
       totalCount={items.length}
       depth={field.depth}
       onAdd={handleAdd}
+      disabled={disabled}
     >
       {arrayField}
     </NestedGroup>
@@ -146,6 +147,7 @@ function RecordObjectNestedGroup({
       totalCount={entries.length}
       depth={field.depth}
       onAdd={handleAdd}
+      disabled={disabled}
     >
       {recordField}
     </NestedGroup>
@@ -549,7 +551,10 @@ function BooleanChip({ value }: { value: boolean }) {
   const localize = useLocalize();
   return (
     <span
-      className={cn('boolean-chip', value ? 'boolean-chip-true' : 'boolean-chip-false')}
+      className={cn(
+        'boolean-chip self-start',
+        value ? 'boolean-chip-true' : 'boolean-chip-false',
+      )}
       aria-label={localize(value ? 'com_ui_true' : 'com_ui_false')}
     >
       {localize(value ? 'com_ui_true' : 'com_ui_false')}
@@ -565,6 +570,7 @@ export function NestedGroup({
   depth = 0,
   onAdd,
   addLabel,
+  disabled,
   children,
 }: {
   label: string;
@@ -575,6 +581,12 @@ export function NestedGroup({
   /** When provided, renders a "+ Add" button inline in the header. */
   onAdd?: () => void;
   addLabel?: string;
+  /**
+   * When true, the caret/collapse affordance is dropped and the group renders
+   * flat with a static heading. Used in fully read-only sections where the
+   * expand/collapse interaction would be misleading.
+   */
+  disabled?: boolean;
   children: ReactNode;
 }) {
   const localize = useLocalize();
@@ -584,6 +596,33 @@ export function NestedGroup({
   const { isExpanded, hasEverExpanded, sectionRef, toggle, handleAddClick } = useCollapsibleSection(
     { defaultExpanded: hasConfigured, onAdd },
   );
+
+  if (disabled) {
+    return (
+      <section
+        ref={sectionRef}
+        id={sectionId}
+        aria-label={label}
+        className={cn(depth > 0 ? 'mt-3' : 'mt-4', 'flex flex-col')}
+        style={indent ? { paddingLeft: indent } : undefined}
+      >
+        <div className="flex items-center gap-2 border-b border-(--cui-color-stroke-default) py-2 pl-1">
+          <span className="text-sm font-medium text-(--cui-color-text-default)">{label}</span>
+          {totalCount > 0 && (
+            <span
+              className={cn(
+                'config-count-badge',
+                hasConfigured ? 'config-count-badge-active' : 'config-count-badge-muted',
+              )}
+            >
+              {configuredCount}/{totalCount}
+            </span>
+          )}
+        </div>
+        {children}
+      </section>
+    );
+  }
 
   return (
     <section
@@ -852,8 +891,9 @@ function NestedGroupWithAddField({
   return (
     <NestedGroup
       label={label}
-      onAdd={hasHideable ? () => addFieldRef.current?.() : undefined}
+      onAdd={!disabled && hasHideable ? () => addFieldRef.current?.() : undefined}
       addLabel={localize('com_config_add_field')}
+      disabled={disabled}
     >
       <InlineFieldRenderer
         fields={fields}
@@ -960,6 +1000,7 @@ export function renderInlineField(
           id={fieldId}
           checked={Boolean(fieldValue)}
           onChange={(checked) => onChange(field.key, checked)}
+          disabled={disabled}
           aria-label={fieldLabel}
         />
       </InlineRow>
@@ -1217,6 +1258,7 @@ export function FieldRenderer({
               configuredCount={nestedCounts.configured}
               totalCount={nestedCounts.total}
               depth={group.field.depth}
+              disabled={disabled}
             >
               <FieldRenderer
                 fields={group.field.children!}

--- a/src/components/configuration/fields/ListField.tsx
+++ b/src/components/configuration/fields/ListField.tsx
@@ -61,21 +61,29 @@ export function ListField({
 
         let control: React.ReactNode;
         if (options) {
-          control = (
-            <select
-              value={value}
-              onChange={(e) => handleChange(index, e.target.value)}
-              disabled={disabled}
-              aria-label={itemLabel}
-              className="config-input flex-1"
-            >
-              {options.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-          );
+          if (disabled) {
+            const matchedLabel = options.find((o) => o.value === value)?.label ?? value;
+            control = (
+              <span className="config-input flex-1" aria-label={itemLabel}>
+                {matchedLabel}
+              </span>
+            );
+          } else {
+            control = (
+              <select
+                value={value}
+                onChange={(e) => handleChange(index, e.target.value)}
+                aria-label={itemLabel}
+                className="config-input flex-1"
+              >
+                {options.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            );
+          }
         } else if (variant === 'inline-edit') {
           control = (
             <input

--- a/src/components/configuration/sections/EndpointsRenderer.tsx
+++ b/src/components/configuration/sections/EndpointsRenderer.tsx
@@ -574,6 +574,7 @@ function ProviderSection({
               totalCount={restChildren.length}
               configuredCount={restConfigured}
               depth={2}
+              disabled={rendererProps.disabled}
             >
               <FieldRenderer fields={restChildren} {...rendererProps} />
             </NestedGroup>
@@ -614,30 +615,39 @@ export function CustomEndpointsRenderer(props: t.FieldRendererProps) {
     onChange(path, [...items, entry]);
   };
 
+  const isEmpty = items.length === 0;
+
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-3 py-2">
-        <button
-          type="button"
-          onClick={() => setCreateOpen(true)}
+      {!disabled && (
+        <div className="flex items-center gap-3 py-2">
+          <button
+            type="button"
+            onClick={() => setCreateOpen(true)}
+            className="config-add-btn"
+          >
+            <Icon name="plus" size="sm" />
+            <span>{localize('com_config_create_endpoint')}</span>
+          </button>
+        </div>
+      )}
+      {disabled && isEmpty ? (
+        <div className="py-3 text-sm text-(--cui-color-text-muted)">
+          {localize('com_config_no_custom_endpoints')}
+        </div>
+      ) : (
+        <ArrayObjectField
+          id={`${path.replace(/\./g, '-')}`}
+          value={value}
+          fields={customField.children ?? []}
+          onChange={(v) => onChange(path, v)}
+          onEntryChange={(index, v) => onChange(`${path}.${index}`, v)}
           disabled={disabled}
-          className="config-add-btn"
-        >
-          <Icon name="plus" size="sm" />
-          <span>{localize('com_config_create_endpoint')}</span>
-        </button>
-      </div>
-      <ArrayObjectField
-        id={`${path.replace(/\./g, '-')}`}
-        value={value}
-        fields={customField.children ?? []}
-        onChange={(v) => onChange(path, v)}
-        onEntryChange={(index, v) => onChange(`${path}.${index}`, v)}
-        disabled={disabled}
-        hideAddButton
-        renderFields={renderGroupedEndpointFields}
-        entryIdPrefix={`section-${path.split('.')[0]}-custom`}
-      />
+          hideAddButton
+          renderFields={renderGroupedEndpointFields}
+          entryIdPrefix={`section-${path.split('.')[0]}-custom`}
+        />
+      )}
       <CreateCustomEndpointDialog
         open={createOpen}
         onClose={() => setCreateOpen(false)}

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -906,19 +906,27 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
     [onChange, path],
   );
 
+  const isEmpty = entries.length === 0;
+
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-3 py-2">
-        <button
-          type="button"
-          onClick={() => setCreateOpen(true)}
-          disabled={disabled}
-          className="config-add-btn"
-        >
-          <Icon name="plus" size="sm" />
-          <span>{localize('com_config_create_mcp_server')}</span>
-        </button>
-      </div>
+      {!disabled && (
+        <div className="flex items-center gap-3 py-2">
+          <button
+            type="button"
+            onClick={() => setCreateOpen(true)}
+            className="config-add-btn"
+          >
+            <Icon name="plus" size="sm" />
+            <span>{localize('com_config_create_mcp_server')}</span>
+          </button>
+        </div>
+      )}
+      {disabled && isEmpty && (
+        <div className="py-3 text-sm text-(--cui-color-text-muted)">
+          {localize('com_config_no_mcp_servers')}
+        </div>
+      )}
       {entries.map(([key, entryValue]) => (
         <McpEntryRow
           key={key}

--- a/src/components/configuration/sections/McpServersRenderer.tsx
+++ b/src/components/configuration/sections/McpServersRenderer.tsx
@@ -943,7 +943,7 @@ export function McpServersRenderer(props: t.FieldRendererProps) {
           justAdded={key === justAddedKey}
         />
       ))}
-      {entries.length === 0 && (
+      {!disabled && entries.length === 0 && (
         <p className="py-2 text-sm text-(--cui-color-text-muted)">
           {localize('com_config_no_entries')}
         </p>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -70,6 +70,8 @@
   "com_config_select_field": "Select a field...",
   "com_config_more_settings": "More settings",
   "com_config_create_endpoint": "Create endpoint",
+  "com_config_no_custom_endpoints": "No custom endpoints configured",
+  "com_config_no_mcp_servers": "No MCP servers configured",
   "com_config_endpoint_name_required": "Endpoint name is required",
   "com_config_create_mcp_server": "Create MCP server",
   "com_config_server_name": "Server name",


### PR DESCRIPTION
## Summary

Cleans up the disabled-state UX in the config editor. The current behavior leaves a number of interactive affordances visible in fully read-only sections where the disabled state is ambiguous, misleading, or silently broken: a row-level `pointer-events-none` blocks legitimate header carets, an inline `ToggleField` still actuates and mutates state without surfacing the save bar, the `BooleanChip` stand-in stretches edge-to-edge in its flex slot, native disabled `<select>` controls keep their browser caret in a flat read-only view, expand carets on nested groups hint at write affordances that no longer exist, and the MCP and Custom Endpoints sections render inert "+ Create" buttons against a blank list when the user has no write capability.

This PR replaces each of those with cleaner read-only stand-ins. No behavior change for users who hold write capability on a section; all changes are gated on the existing `disabled` prop.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Implementation

- **`ConfigRow`**: drop row-level `pointer-events-none` when disabled. The catch-all overreached into the `SectionHeader` (blocking carets and other purely visual controls) and is unnecessary now that every value control inside `SectionControls` self-blocks via its own `disabled` attribute. Audited every `controlType` branch in `FieldRenderer` and every component in `src/components/configuration/fields/` to confirm.
- **`FieldRenderer` (inline `ToggleField`)**: was missing the `disabled` prop. Inline toggles in disabled sections still actuated and silently mutated `editedValues` without triggering the save bar — the change registered as dirty against a tab the user could not save. Fixed.
- **`FieldRenderer` (`BooleanChip`)**: added `self-start`. `SectionControls` is a `flex flex-col` slot with default `align-items: stretch`, which made the chip span the full value area. Now sits at its natural pill width like `ToggleField` does.
- **`FieldRenderer` (`NestedGroup`)**: gains a `disabled` prop. When set, the caret/collapse button is dropped and the group renders flat with a static heading. Carets in fully read-only sections hinted at interactivity that no longer mattered. Threaded through all four `NestedGroup` call sites in `FieldRenderer` plus the "More settings" group in `EndpointsRenderer`.
- **`fields/ListField`**: when disabled and the field has enum `options`, swap the native `<select>` for a static `<span>` showing the matched option label. Browsers render their own dropdown caret on disabled `<select>` regardless of any CSS, which conflicted with the new flat read-only look.
- **`sections/EndpointsRenderer`** and **`sections/McpServersRenderer`**: hide the "+ Create endpoint" / "+ Create MCP server" button entirely when disabled rather than rendering an inert button next to a read-only list. When disabled and the list is empty, render a muted "No custom endpoints configured" / "No MCP servers configured" placeholder so the expanded section is not just empty space.
- **`locales/en/translation.json`**: two new keys (`com_config_no_custom_endpoints`, `com_config_no_mcp_servers`). `locize-i18n-sync` handles the rest of the languages.

## Testing

- `bun run lint`: clean.
- `npx tsc --noEmit`: clean.
- Manual: walked through the disabled state for Custom Endpoints, MCP Servers, the Agents tab, and a few nested-group sections. Carets no longer render, create buttons no longer render, inline toggles can no longer be clicked, `BooleanChip` pills sit at natural pill width, list-of-enum fields render as static text, empty-section placeholders appear in the expected places.
- Spot-checked the write path on the same sections to confirm: carets, toggles, selects, and create buttons all functional when the user holds write capability.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes gated on the existing `disabled` prop; no auth, persistence, or API behavior changes.
> 
> **Overview**
> Improves how **read-only** config sections look and behave when `disabled` is set, without changing the editable path for users who can write.
> 
> **`ConfigRow`** no longer applies row-level `pointer-events-none` on disabled rows, so header affordances are not blocked while individual controls still honor `disabled`.
> 
> **`FieldRenderer`** threads `disabled` into inline **`ToggleField`** (fixes toggles that could still mutate state), **`NestedGroup`** (flat static heading instead of expand/collapse), and **`BooleanChip`** (`self-start` so pills do not stretch full width). **`ListField`** shows enum values as static text instead of a disabled `<select>` with a dropdown caret.
> 
> **Custom Endpoints** and **MCP Servers** hide create buttons when disabled; empty read-only lists show new muted placeholders (`com_config_no_custom_endpoints`, `com_config_no_mcp_servers`). MCP still shows the generic “no entries” hint only when editable and empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18631e7da18f0f7836908140accf6072f5424605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->