### PR TITLE
Feat/export yaml

### DIFF
--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -1,3 +1,4 @@
+import yaml from 'js-yaml';
 import { createPortal } from 'react-dom';
 import { Icon } from '@clickhouse/click-ui';
 import { PrincipalType } from 'librechat-data-provider';
@@ -746,6 +747,18 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     [isEditingScope, editingScope, importMutation, showImportSuccess, handleImportAsProfile],
   );
 
+  const handleExport = useCallback(() => {
+    const source = dbOverrides && Object.keys(dbOverrides).length > 0 ? dbOverrides : configValues;
+    const yamlStr = yaml.dump(source ?? {}, { lineWidth: -1, noRefs: true });
+    const blob = new Blob([yamlStr], { type: 'application/x-yaml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'librechat.yaml';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [dbOverrides, configValues]);
+
   const highlightRef = useHighlightRef(highlightField);
   const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
   const [tocEl, setTocEl] = useState<HTMLElement | null>(null);
@@ -929,6 +942,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
               : undefined
           }
           onImportClick={() => setImportOpen(true)}
+          onExportClick={handleExport}
           showReset={!isEditingScope && dbOverridePaths.size > 0}
           resetDisabled={isDirty || !canManageConfig}
           resetTitle={resetBaseTitle}
@@ -1058,6 +1072,7 @@ function HeaderActions({
   importDisabled,
   importTitle,
   onImportClick,
+  onExportClick,
   showReset,
   resetDisabled,
   resetTitle,
@@ -1070,6 +1085,7 @@ function HeaderActions({
   importDisabled: boolean;
   importTitle?: string;
   onImportClick: () => void;
+  onExportClick: () => void;
   showReset: boolean;
   resetDisabled: boolean;
   resetTitle?: string;
@@ -1085,22 +1101,33 @@ function HeaderActions({
     setPortalTarget(document.getElementById('header-actions-portal'));
   }, []);
 
+  const btnClass =
+    'flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border border-(--cui-color-stroke-default) bg-transparent px-3 py-1.5 text-sm text-(--cui-color-text-default) transition-colors hover:bg-(--cui-color-background-hover) disabled:cursor-not-allowed disabled:opacity-50';
+
   const content = (
     <>
       {showImport && (
-        <button
-          type="button"
-          onClick={onImportClick}
-          disabled={importDisabled}
-          aria-disabled={importDisabled || undefined}
-          title={importTitle}
-          className="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border border-(--cui-color-stroke-default) bg-transparent px-3 py-1.5 text-sm text-(--cui-color-text-default) transition-colors hover:bg-(--cui-color-background-hover) disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <span aria-hidden="true">
-            <Icon name="upload" size="xs" />
-          </span>
-          {localize('com_config_import_yaml')}
-        </button>
+        <>
+          <button type="button" onClick={onExportClick} className={btnClass}>
+            <span aria-hidden="true">
+              <Icon name="download" size="xs" />
+            </span>
+            {localize('com_config_export_yaml')}
+          </button>
+          <button
+            type="button"
+            onClick={onImportClick}
+            disabled={importDisabled}
+            aria-disabled={importDisabled || undefined}
+            title={importTitle}
+            className={btnClass}
+          >
+            <span aria-hidden="true">
+              <Icon name="upload" size="xs" />
+            </span>
+            {localize('com_config_import_yaml')}
+          </button>
+        </>
       )}
       {showReset && (
         <button

--- a/src/components/configuration/ConfigPage.tsx
+++ b/src/components/configuration/ConfigPage.tsx
@@ -755,8 +755,10 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
     const a = document.createElement('a');
     a.href = url;
     a.download = 'librechat.yaml';
+    document.body.appendChild(a);
     a.click();
-    URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 100);
   }, [dbOverrides, configValues]);
 
   const highlightRef = useHighlightRef(highlightField);
@@ -942,6 +944,7 @@ export function ConfigPage({ initialTab, highlightField, initialScope }: t.Confi
               : undefined
           }
           onImportClick={() => setImportOpen(true)}
+          exportDisabled={!configValues}
           onExportClick={handleExport}
           showReset={!isEditingScope && dbOverridePaths.size > 0}
           resetDisabled={isDirty || !canManageConfig}
@@ -1072,6 +1075,7 @@ function HeaderActions({
   importDisabled,
   importTitle,
   onImportClick,
+  exportDisabled,
   onExportClick,
   showReset,
   resetDisabled,
@@ -1085,6 +1089,7 @@ function HeaderActions({
   importDisabled: boolean;
   importTitle?: string;
   onImportClick: () => void;
+  exportDisabled: boolean;
   onExportClick: () => void;
   showReset: boolean;
   resetDisabled: boolean;
@@ -1108,7 +1113,7 @@ function HeaderActions({
     <>
       {showImport && (
         <>
-          <button type="button" onClick={onExportClick} className={btnClass}>
+          <button type="button" onClick={onExportClick} disabled={exportDisabled} aria-disabled={exportDisabled || undefined} className={btnClass}>
             <span aria-hidden="true">
               <Icon name="download" size="xs" />
             </span>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -122,6 +122,7 @@
   "com_config_saving": "Saving...",
   "com_config_saved": "Changes saved",
   "com_config_save_error": "Failed to save",
+  "com_config_export_yaml": "Export YAML",
   "com_toast_group_created": "Group \"{{name}}\" created",
   "com_toast_group_updated": "Group \"{{name}}\" updated",
   "com_toast_group_deleted": "Group \"{{name}}\" deleted",


### PR DESCRIPTION
## Summary

Adds an **Export YAML** button to the configuration page header, next to the existing Import YAML button. Clicking it downloads the current configured overrides (falling back to the full resolved config if no overrides exist) as `librechat.yaml` — entirely client-side using `js-yaml` (already a dependency), with no extra server roundtrip.

Fixes applied after review:
- Anchor appended to `document.body` before `.click()` and removed after — Firefox requires the element to be in the DOM to trigger a file download
- `URL.revokeObjectURL` deferred with `setTimeout` so the browser reads the blob before it is revoked
- Export button disabled while config data is still loading (consistent with the import button guard)
- Added `com_config_export_yaml` i18n key

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Translation update

## Testing

1. Start the admin panel (`bun run dev`)
2. Navigate to **Configuration**
3. Click **Export YAML** — a `librechat.yaml` file should download containing the current configuration overrides
4. If no overrides are set, the export falls back to the full resolved config
5. Verify the button is disabled while the page is still loading
6. Verify the download works in both Chrome and Firefox

### **Test Configuration**:
- Browsers: Chrome, Firefox

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes