### PR TITLE
🐳 ci: Build & Publish Versioned Image on Release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,8 @@ name: Docker Image Publish
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
   push:
     branches:
       - main
@@ -37,13 +39,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/clickhouse/librechat-admin-panel
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=long,prefix=,enable={{is_default_branch}}
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           push: true
-          tags: |
-            ghcr.io/clickhouse/librechat-admin-panel:${{ github.sha }}
-            ghcr.io/clickhouse/librechat-admin-panel:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Publishing a GitHub release (e.g. [v1.0.0](https://github.com/ClickHouse/librechat-admin-panel/releases/tag/v1.0.0)) currently builds **no** Docker image: the `Docker Image Publish` workflow only triggers on `main` pushes and tags images with `:<sha>` and `:latest`.

This adds release-driven, versioned image builds.

## Changes

- **New trigger:** `release: published` (in addition to the existing `workflow_dispatch` and `main` push triggers).
- **Tag generation via `docker/metadata-action`:**

| Event | Image tags pushed |
| --- | --- |
| Release `v1.0.0` published | `:1.0.0`, `:1.0`, `:1` |
| Push to `main` | `:latest`, `:<full-sha>` _(unchanged)_ |

`latest` deliberately keeps tracking `main` (not the latest release), so the existing `docker-compose.yml` `:latest` reference is unaffected. The full-`<sha>` tag format is preserved.

## Note on the existing v1.0.0 release

The `v1.0.0` tag points to a commit that predates this workflow, so merging this **will not** retroactively build the `v1.0.0` image — GitHub runs the workflow version that exists at the released commit. The first versioned build will happen on the next release cut after this merges (or by re-pointing `v1.0.0` to a commit that includes this workflow). See the PR discussion for options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)