### PR TITLE
⚠️ fix: Keep Session Module Server-only

### DIFF
--- a/src/server/auth.oauth.test.ts
+++ b/src/server/auth.oauth.test.ts
@@ -25,10 +25,10 @@ vi.mock('@tanstack/react-query', () => ({
 }));
 
 vi.mock('./session', () => ({
-  SESSION_CONFIG: {
+  getSessionConfig: () => ({
     revalidationInterval: 60_000,
     idleTimeout: 30 * 60 * 1000,
-  },
+  }),
   useAppSession: vi.fn(async () => ({
     data: sessionState.data,
     update: updateSession,

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -8,7 +8,7 @@ import type * as t from '@/types';
 import { getApiBaseUrl, getServerApiUrl } from './utils/url';
 import { refreshAdminTokenDeduped } from './utils/refresh';
 import { buildOAuthExchangePayload } from './utils/oauth';
-import { useAppSession, SESSION_CONFIG } from './session';
+import { useAppSession, getSessionConfig } from './session';
 
 /** Extract a named cookie value from `set-cookie` response headers. */
 function extractCookieValue(response: Response, name: string): string | undefined {
@@ -190,14 +190,14 @@ export const verifyAdminTokenFn = createServerFn({ method: 'GET' }).handler(asyn
     }
 
     const now = Date.now();
+    const sessionConfig = getSessionConfig();
 
-    if (lastActivity && now - lastActivity > SESSION_CONFIG.idleTimeout) {
+    if (lastActivity && now - lastActivity > sessionConfig.idleTimeout) {
       await clearSession(session);
       return { valid: false, error: 'Session expired due to inactivity' };
     }
 
-    const needsRevalidation =
-      !lastVerified || now - lastVerified > SESSION_CONFIG.revalidationInterval;
+    const needsRevalidation = !lastVerified || now - lastVerified > sessionConfig.revalidationInterval;
 
     if (needsRevalidation) {
       try {

--- a/src/server/session.test.ts
+++ b/src/server/session.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { SESSION_CONFIG } from './session';
+import { getSessionConfig } from './session';
 
-describe('SESSION_CONFIG', () => {
+describe('getSessionConfig', () => {
   it('revalidation interval is 60 seconds', () => {
-    expect(SESSION_CONFIG.revalidationInterval).toBe(60_000);
+    expect(getSessionConfig().revalidationInterval).toBe(60_000);
   });
 
   it('idle timeout defaults to 30 minutes', () => {
-    expect(SESSION_CONFIG.idleTimeout).toBe(30 * 60 * 1000);
+    expect(getSessionConfig().idleTimeout).toBe(30 * 60 * 1000);
   });
 });

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1,3 +1,4 @@
+import { createServerOnlyFn } from '@tanstack/react-start';
 import { useSession } from '@tanstack/react-start/server';
 import type * as t from '@/types';
 
@@ -42,16 +43,23 @@ if (!process.env.SESSION_SECRET && process.env.NODE_ENV === 'development') {
 
 const sessionCookiePath = process.env.VITE_BASE_PATH || '/';
 
-export function useAppSession(): ReturnType<typeof useSession<t.SessionData>> {
-  return useSession<t.SessionData>({
-    name: 'admin-session',
-    password: sessionSecret || '',
-    cookie: {
-      path: sessionCookiePath,
-      secure: sessionCookieSecure,
-      sameSite: 'lax',
-      httpOnly: true,
-      maxAge: 60 * 60 * 24 * 7,
-    },
-  });
-}
+/**
+ * `createServerOnlyFn`: this module is reachable from client-bundled routes
+ * transitively (e.g. via server/utils/refresh.ts -> server/session.ts, even
+ * though every real caller is server-only), so the bundler can't otherwise
+ * prove `useSession` is safe to keep out of the client build.
+ */
+export const useAppSession = createServerOnlyFn(
+  (): ReturnType<typeof useSession<t.SessionData>> =>
+    useSession<t.SessionData>({
+      name: 'admin-session',
+      password: sessionSecret || '',
+      cookie: {
+        path: sessionCookiePath,
+        secure: sessionCookieSecure,
+        sameSite: 'lax',
+        httpOnly: true,
+        maxAge: 60 * 60 * 24 * 7,
+      },
+    }),
+);

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -8,52 +8,61 @@ const MIN_SESSION_SECRET_LENGTH = 32;
 const REVALIDATION_INTERVAL_MS = 60_000;
 const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 
-const envIdleTimeout = Number(process.env.ADMIN_SESSION_IDLE_TIMEOUT_MS);
-const effectiveIdleTimeout =
-  Number.isFinite(envIdleTimeout) && envIdleTimeout > 0 ? envIdleTimeout : DEFAULT_IDLE_TIMEOUT_MS;
+function resolveSessionSecret(): string {
+  const sessionSecret =
+    process.env.SESSION_SECRET || (process.env.NODE_ENV === 'development' ? DEV_SECRET : undefined);
 
-const sessionCookieSecure =
-  process.env.SESSION_COOKIE_SECURE !== undefined
-    ? process.env.SESSION_COOKIE_SECURE === 'true'
-    : process.env.NODE_ENV === 'production';
+  if (!sessionSecret) {
+    throw new Error('SESSION_SECRET environment variable must be set for admin session encryption.');
+  }
 
-export const SESSION_CONFIG = {
-  revalidationInterval: REVALIDATION_INTERVAL_MS,
-  idleTimeout: effectiveIdleTimeout,
-} as const;
+  if (sessionSecret.length < MIN_SESSION_SECRET_LENGTH) {
+    throw new Error(
+      `SESSION_SECRET must be at least ${MIN_SESSION_SECRET_LENGTH} characters for admin session encryption.`,
+    );
+  }
 
-const sessionSecret =
-  process.env.SESSION_SECRET || (process.env.NODE_ENV === 'development' ? DEV_SECRET : undefined);
+  if (!process.env.SESSION_SECRET && process.env.NODE_ENV === 'development') {
+    console.warn(
+      '[session] Using hardcoded DEV_SECRET — set SESSION_SECRET for production-like environments',
+    );
+  }
 
-if (!sessionSecret) {
-  throw new Error('SESSION_SECRET environment variable must be set for admin session encryption.');
+  return sessionSecret;
 }
-
-if (sessionSecret.length < MIN_SESSION_SECRET_LENGTH) {
-  throw new Error(
-    `SESSION_SECRET must be at least ${MIN_SESSION_SECRET_LENGTH} characters for admin session encryption.`,
-  );
-}
-
-if (!process.env.SESSION_SECRET && process.env.NODE_ENV === 'development') {
-  console.warn(
-    '[session] Using hardcoded DEV_SECRET — set SESSION_SECRET for production-like environments',
-  );
-}
-
-const sessionCookiePath = process.env.VITE_BASE_PATH || '/';
 
 /**
  * `createServerOnlyFn`: this module is reachable from client-bundled routes
  * transitively (e.g. via server/utils/refresh.ts -> server/session.ts, even
  * though every real caller is server-only), so the bundler can't otherwise
- * prove `useSession` is safe to keep out of the client build.
+ * prove these are safe to keep out of the client build. Every env-dependent
+ * computation (including anything that can throw) has to live inside these
+ * wrapped closures rather than at module scope — module-level code still
+ * runs whenever the module is merely imported into the client bundle, even
+ * though the wrapped function bodies themselves get stubbed out.
  */
+export const getSessionConfig = createServerOnlyFn(() => {
+  const envIdleTimeout = Number(process.env.ADMIN_SESSION_IDLE_TIMEOUT_MS);
+  const idleTimeout =
+    Number.isFinite(envIdleTimeout) && envIdleTimeout > 0 ? envIdleTimeout : DEFAULT_IDLE_TIMEOUT_MS;
+
+  return {
+    revalidationInterval: REVALIDATION_INTERVAL_MS,
+    idleTimeout,
+  } as const;
+});
+
 export const useAppSession = createServerOnlyFn(
-  (): ReturnType<typeof useSession<t.SessionData>> =>
-    useSession<t.SessionData>({
+  (): ReturnType<typeof useSession<t.SessionData>> => {
+    const sessionCookieSecure =
+      process.env.SESSION_COOKIE_SECURE !== undefined
+        ? process.env.SESSION_COOKIE_SECURE === 'true'
+        : process.env.NODE_ENV === 'production';
+    const sessionCookiePath = process.env.VITE_BASE_PATH || '/';
+
+    return useSession<t.SessionData>({
       name: 'admin-session',
-      password: sessionSecret || '',
+      password: resolveSessionSecret(),
       cookie: {
         path: sessionCookiePath,
         secure: sessionCookieSecure,
@@ -61,5 +70,6 @@ export const useAppSession = createServerOnlyFn(
         httpOnly: true,
         maxAge: 60 * 60 * 24 * 7,
       },
-    }),
+    });
+  },
 );

--- a/src/server/utils/refresh.ts
+++ b/src/server/utils/refresh.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { createServerOnlyFn } from '@tanstack/react-start';
 import { getRequestHeader } from '@tanstack/react-start/server';
 import type * as t from '@/types';
 import { useAppSession } from '../session';
@@ -20,13 +21,18 @@ export interface RefreshedTokenset {
  * Forwards the deployment's tenant header to the LibreChat backend so that
  * `preAuthTenantMiddleware` can scope the refresh lookup. Returns `undefined`
  * (no header) when the BFF request didn't carry one — single-tenant deploys.
+ *
+ * `createServerOnlyFn` (not a plain function): this file is reachable from a
+ * client-bundled route (login.tsx -> @/server -> scopes.ts -> utils/api.ts)
+ * even though every actual caller here is server-only, so the bundler can't
+ * otherwise prove `getRequestHeader` is safe to keep out of the client build.
  */
-function readTenantHeader(): string | undefined {
+const readTenantHeader = createServerOnlyFn((): string | undefined => {
   const raw = getRequestHeader('x-tenant-id');
   if (typeof raw !== 'string') return undefined;
   const trimmed = raw.trim();
   return trimmed.length > 0 ? trimmed : undefined;
-}
+});
 
 function extractRefreshTokenCookie(response: Response): string | undefined {
   const setCookies = response.headers.getSetCookie();


### PR DESCRIPTION
## Summary

The production build has been failing since #99 merged (see the docker-publish workflow run on main). TanStack Start's import-protection plugin rejects the client bundle:

```
[import-protection] Import denied in client environment
Denied by specifier pattern: @tanstack/react-start/server
Importer: src/server/utils/refresh.ts
```

`refresh.ts` calls `getRequestHeader` from `@tanstack/react-start/server` as a plain function, and this file is reachable from a client-bundled route (`login.tsx -> @/server -> scopes.ts -> utils/api.ts -> refresh.ts`) even though every real caller is server-only. The plugin can't prove that from a bare import alone and rejects the build. Fixing that surfaces the same issue one level deeper: `refresh.ts` also imports `session.ts`, which calls `useSession` the same unwrapped way.

## Fix

First commit wraps both `readTenantHeader` and `useAppSession` in `createServerOnlyFn`, the pattern the compiler's own error message points to.

That fix alone still leaves a real bug: `createServerOnlyFn` only replaces the wrapped function's body in the client bundle, it doesn't touch the rest of the module's top-level statements. `session.ts` computed `SESSION_SECRET` validation and cookie settings, and threw, at module scope, so that code still ran the instant the module was pulled into the client bundle transitively, including inside the browser's own JS runtime, even with `useAppSession` itself correctly stubbed out. Bundlers don't tree-shake a module with side effects just because its exports go unused, so this threw unconditionally in the browser, where `process.env` is always empty, regardless of whether the server itself has `SESSION_SECRET` set.

Second commit moves the throwing validation and env reads into the `useAppSession` closure, and turns `SESSION_CONFIG` (a plain top-level const) into a lazily-computed `getSessionConfig()`, both wrapped in `createServerOnlyFn`. Nothing in this module now executes merely by being imported.

## Testing

Fresh clone, fresh `bun install`, from-scratch `bun run build` (both client and SSR passes succeed, including with `SESSION_SECRET` unset), confirmed the error string no longer appears anywhere in the client bundle output, `tsc --noEmit` clean, `eslint` clean, full test suite (799 tests) passing with `SESSION_SECRET` set, and a real browser (Playwright) hit against a locally built production server showing zero console errors.