### PR TITLE
🛂 fix: Gate App Layout Pessimistically While Capabilities Load

### DIFF
--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect } from 'react';
 import { Icon } from '@clickhouse/click-ui';
 import { createFileRoute, Outlet, useRouter, Link, redirect } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
+import { AccessDenied, PermissionsUnavailable } from '@/components/shared';
 import { useCapabilities, useCommandMenu, useLocalize } from '@/hooks';
 import { CommandMenu } from '@/components/CommandMenu';
-import { AccessDenied } from '@/components/shared';
 import { SystemCapabilities } from '@/constants';
 import { Sidebar } from '@/components/Sidebar';
 import { verifyAdminTokenFn } from '@/server';
@@ -68,7 +68,9 @@ function AppLayout() {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  if (!isLoading && !isError && !hasCapability(SystemCapabilities.ACCESS_ADMIN)) {
+  if (isLoading) return null;
+  if (isError) return <PermissionsUnavailable />;
+  if (!hasCapability(SystemCapabilities.ACCESS_ADMIN)) {
     return <AccessDenied />;
   }
 


### PR DESCRIPTION
## Summary

The `_app` layout guard renders `AccessDenied` only after the effective-capabilities query has settled:

```tsx
if (!isLoading && !isError && !hasCapability(SystemCapabilities.ACCESS_ADMIN)) {
  return <AccessDenied />;
}
```

This has two problems for a logged-in user who lacks `ACCESS_ADMIN`:

- **Authorized-UI flash:** while the query is in flight, the full authenticated chrome (sidebar, header, active route) renders for the duration of the round trip, then flips to `AccessDenied`. Child data queries are still rejected server-side, so no data is exposed, but the unauthorized user briefly sees the admin panel's layout and navigation.
- **Fail-open on error:** if the capabilities query errors (anything not mapped by the 401/403/404/503 patterns in `useCapabilities`), `!isError` prevents the guard from ever tripping and the layout stays rendered indefinitely.

## Fix

Applies the same convention the child routes (`access.tsx`, etc.) already use, at the layout level: render nothing while loading, `PermissionsUnavailable` (with its reload affordance) on error, and `AccessDenied` only on a settled missing capability. The gate now fails closed in every non-success state.

## Testing

`tsc --noEmit` clean, `eslint` clean, full test suite (799 tests) passing, from-scratch production build succeeds.