### PR TITLE
🪦 feat: Request Tombstones, Memory Watermarks & Server Error Logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,7 @@ SESSION_SECRET=
 # ADMIN_PANEL_INDEX_CACHE_CONTROL=   # overrides INDEX_CACHE_CONTROL for admin panel
 # ADMIN_PANEL_INDEX_PRAGMA=          # overrides INDEX_PRAGMA for admin panel
 # ADMIN_PANEL_INDEX_EXPIRES=         # overrides INDEX_EXPIRES for admin panel
+
+# Request and memory observability
+# ADMIN_PANEL_REQUEST_LOG=false      # disables request arrival/completion logging (default: enabled)
+# ADMIN_PANEL_MEMORY_LOG_THRESHOLDS_MB=256,384,448 # RSS thresholds in MiB, each logged once per upward crossing

--- a/server.ts
+++ b/server.ts
@@ -112,6 +112,7 @@ async function withHttpObservability(
   req: Request,
   pathname: string,
   getResponse: () => Response | Promise<Response>,
+  options?: { monitorBody?: boolean },
 ): Promise<Response> {
   const path = normalizeMetricsPath(pathname);
   const end = httpRequestDurationSeconds.startTimer({ method: req.method, path });
@@ -158,7 +159,10 @@ async function withHttpObservability(
 
   // Bun discards a HEAD body without reading or cancelling it, so a monitored
   // stream would never settle and the completion line would never be emitted.
-  if (req.method === 'HEAD') {
+  // A native file body must also be left intact: replacing it with a JavaScript
+  // stream costs Bun's sendfile path and the Content-Length it derives from the
+  // file, turning every static asset into a chunked transfer.
+  if (req.method === 'HEAD' || options?.monitorBody === false) {
     logDone(statusCode);
     return res;
   }
@@ -175,11 +179,16 @@ async function buildStaticRoutes(): Promise<Record<string, (req: Request) => Pro
     const cache = getCacheHeaders(path);
     const routePath = `${BASE_PATH}/${path}`;
     routes[routePath] = (req) =>
-      withHttpObservability(req, routePath, () => {
-        const res = new Response(file, { headers: { 'Content-Type': file.type, ...cache } });
-        applySecurityHeaders(res.headers);
-        return res;
-      });
+      withHttpObservability(
+        req,
+        routePath,
+        () => {
+          const res = new Response(file, { headers: { 'Content-Type': file.type, ...cache } });
+          applySecurityHeaders(res.headers);
+          return res;
+        },
+        { monitorBody: false },
+      );
   }
   return routes;
 }

--- a/server.ts
+++ b/server.ts
@@ -134,17 +134,38 @@ async function withHttpObservability(
     }
   }
 
-  const res = await getResponse();
+  const logDone = (status: string, note = ''): void => {
+    const elapsed = Math.round(performance.now() - startedAt);
+    console.log(`[req] ${req.method} ${loggedPath} ${status} ${elapsed}ms${note}`);
+  };
+
+  let res: Response;
+  try {
+    res = await getResponse();
+  } catch (err) {
+    // Bun's error callback turns this into a 500, but that line carries no method or
+    // path, so the arrival tombstone would otherwise never be closed out.
+    httpRequestsTotal.inc({ method: req.method, path, status_code: '500' });
+    end({ status_code: '500' });
+    if (logCompletion) logDone('500', ' handler-error');
+    throw err;
+  }
+
   const statusCode = String(res.status);
   httpRequestsTotal.inc({ method: req.method, path, status_code: statusCode });
   end({ status_code: statusCode });
   if (!logCompletion) return res;
 
-  return reportOnBodyComplete(res, (outcome) => {
-    const elapsed = Math.round(performance.now() - startedAt);
-    const suffix = outcome === 'stream-error' ? ' stream-error' : '';
-    console.log(`[req] ${req.method} ${loggedPath} ${statusCode} ${elapsed}ms${suffix}`);
-  });
+  // Bun discards a HEAD body without reading or cancelling it, so a monitored
+  // stream would never settle and the completion line would never be emitted.
+  if (req.method === 'HEAD') {
+    logDone(statusCode);
+    return res;
+  }
+
+  return reportOnBodyComplete(res, (outcome) =>
+    logDone(statusCode, outcome === 'stream-error' ? ' stream-error' : ''),
+  );
 }
 
 async function buildStaticRoutes(): Promise<Record<string, (req: Request) => Promise<Response>>> {

--- a/server.ts
+++ b/server.ts
@@ -2,6 +2,7 @@ import { Glob } from 'bun';
 import { join } from 'node:path';
 import {
   isProbeRequest,
+  reportOnBodyComplete,
   createFloodGuard,
   formatLoggedPath,
   createMemoryWatermark,
@@ -120,7 +121,7 @@ async function withHttpObservability(
   let logCompletion = false;
   let startedAt = 0;
   let loggedPath = '';
-  if (REQUEST_LOG && !isProbeRequest(req.headers.get('user-agent'))) {
+  if (REQUEST_LOG && !isProbeRequest(req.headers.get('user-agent'), new URL(req.url).pathname)) {
     const { admitted, suppressedInPriorWindow } = floodGuard.admit(Date.now());
     if (suppressedInPriorWindow > 0) {
       console.log(`[req] suppressed ${suppressedInPriorWindow} requests in prior window`);
@@ -137,12 +138,13 @@ async function withHttpObservability(
   const statusCode = String(res.status);
   httpRequestsTotal.inc({ method: req.method, path, status_code: statusCode });
   end({ status_code: statusCode });
-  if (logCompletion) {
-    console.log(
-      `[req] ${req.method} ${loggedPath} ${statusCode} ${Math.round(performance.now() - startedAt)}ms`,
-    );
-  }
-  return res;
+  if (!logCompletion) return res;
+
+  return reportOnBodyComplete(res, (outcome) => {
+    const elapsed = Math.round(performance.now() - startedAt);
+    const suffix = outcome === 'stream-error' ? ' stream-error' : '';
+    console.log(`[req] ${req.method} ${loggedPath} ${statusCode} ${elapsed}ms${suffix}`);
+  });
 }
 
 async function buildStaticRoutes(): Promise<Record<string, (req: Request) => Promise<Response>>> {

--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,13 @@
 import { Glob } from 'bun';
 import { join } from 'node:path';
 import {
+  isProbeRequest,
+  createFloodGuard,
+  formatLoggedPath,
+  createMemoryWatermark,
+  parseMemoryThresholdsMb,
+} from './src/server/logging';
+import {
   metricsResponse,
   httpRequestsTotal,
   httpRequestDurationSeconds,
@@ -97,17 +104,44 @@ type Handler = { default: { fetch: (req: Request) => Promise<Response> } };
 
 const { default: handler } = (await import(SERVER_ENTRY.href)) as Handler;
 
-async function withHttpMetrics(
+const REQUEST_LOG = process.env.ADMIN_PANEL_REQUEST_LOG !== 'false';
+const floodGuard = createFloodGuard();
+
+async function withHttpObservability(
   req: Request,
   pathname: string,
   getResponse: () => Response | Promise<Response>,
 ): Promise<Response> {
   const path = normalizeMetricsPath(pathname);
   const end = httpRequestDurationSeconds.startTimer({ method: req.method, path });
+
+  // The arrival line is logged before the handler runs so that a request that
+  // kills the process still leaves its method and path as the last log line.
+  let logCompletion = false;
+  let startedAt = 0;
+  let loggedPath = '';
+  if (REQUEST_LOG && !isProbeRequest(req.headers.get('user-agent'))) {
+    const { admitted, suppressedInPriorWindow } = floodGuard.admit(Date.now());
+    if (suppressedInPriorWindow > 0) {
+      console.log(`[req] suppressed ${suppressedInPriorWindow} requests in prior window`);
+    }
+    if (admitted) {
+      loggedPath = formatLoggedPath(new URL(req.url).pathname);
+      startedAt = performance.now();
+      console.log(`[req] ${req.method} ${loggedPath}`);
+      logCompletion = true;
+    }
+  }
+
   const res = await getResponse();
   const statusCode = String(res.status);
   httpRequestsTotal.inc({ method: req.method, path, status_code: statusCode });
   end({ status_code: statusCode });
+  if (logCompletion) {
+    console.log(
+      `[req] ${req.method} ${loggedPath} ${statusCode} ${Math.round(performance.now() - startedAt)}ms`,
+    );
+  }
   return res;
 }
 
@@ -118,7 +152,7 @@ async function buildStaticRoutes(): Promise<Record<string, (req: Request) => Pro
     const cache = getCacheHeaders(path);
     const routePath = `${BASE_PATH}/${path}`;
     routes[routePath] = (req) =>
-      withHttpMetrics(req, routePath, () => {
+      withHttpObservability(req, routePath, () => {
         const res = new Response(file, { headers: { 'Content-Type': file.type, ...cache } });
         applySecurityHeaders(res.headers);
         return res;
@@ -139,7 +173,7 @@ const server = Bun.serve({
       const metricsPath = BASE_PATH && url.pathname.startsWith(BASE_PATH)
         ? url.pathname.slice(BASE_PATH.length) || '/'
         : url.pathname;
-      const res = await withHttpMetrics(req, metricsPath, () => handler.fetch(req));
+      const res = await withHttpObservability(req, metricsPath, () => handler.fetch(req));
       const patched = new Response(res.body, res);
       for (const [k, v] of Object.entries(NO_CACHE)) {
         patched.headers.set(k, v);
@@ -148,7 +182,26 @@ const server = Bun.serve({
       return patched;
     },
   },
+  error(error: Error): Response {
+    console.error(`[error] unhandled server error: ${error.message}`, error.stack ?? '');
+    return new Response('Internal Server Error', { status: 500 });
+  },
 });
+
+const memoryWatermark = createMemoryWatermark(
+  parseMemoryThresholdsMb(env.ADMIN_PANEL_MEMORY_LOG_THRESHOLDS_MB),
+);
+const MEMORY_CHECK_INTERVAL_MS = 10_000;
+setInterval(() => {
+  const { rss, heapUsed } = process.memoryUsage();
+  const crossedMb = memoryWatermark.check(rss);
+  if (crossedMb !== null) {
+    const mib = 1024 * 1024;
+    console.log(
+      `[mem] rss=${Math.round(rss / mib)}Mi heapUsed=${Math.round(heapUsed / mib)}Mi (crossed ${crossedMb}Mi)`,
+    );
+  }
+}, MEMORY_CHECK_INTERVAL_MS);
 
 console.log(`Admin panel listening on http://localhost:${server.port}${BASE_PATH}/`);
 

--- a/src/server/logging.test.ts
+++ b/src/server/logging.test.ts
@@ -162,6 +162,21 @@ describe('reportOnBodyComplete', () => {
     expect(outcomes).toEqual(['stream-error']);
   });
 
+  it('reports once when a cancel races a pending read', async () => {
+    const outcomes: string[] = [];
+    /** Never enqueues, so the wrapper's read is still pending when the cancel lands. */
+    const body = new ReadableStream<Uint8Array>({ start() {} });
+
+    const res = reportOnBodyComplete(new Response(body, { status: 200 }), (o) => outcomes.push(o));
+    const reader = res.body!.getReader();
+    const pending = reader.read();
+    await reader.cancel('client gone');
+    await pending.catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(outcomes).toEqual(['stream-error']);
+  });
+
   it('preserves status and headers', () => {
     const res = reportOnBodyComplete(
       new Response('csv', { status: 200, headers: { 'content-type': 'text/csv' } }),

--- a/src/server/logging.test.ts
+++ b/src/server/logging.test.ts
@@ -4,6 +4,7 @@ import {
   createFloodGuard,
   formatLoggedPath,
   createMemoryWatermark,
+  reportOnBodyComplete,
   parseMemoryThresholdsMb,
 } from './logging';
 
@@ -17,9 +18,16 @@ describe('isProbeRequest', () => {
     ['curl/8.7.1', false],
     ['', false],
     [null, false],
-  ])('user-agent %s -> %s', (userAgent, expected) => {
-    expect(isProbeRequest(userAgent)).toBe(expected);
+  ])('user-agent %s on the probe path -> %s', (userAgent, expected) => {
+    expect(isProbeRequest(userAgent, '/health')).toBe(expected);
   });
+
+  it.each(['/', '/api/config', '/admin/users'])(
+    'refuses to suppress %s even for a probe user-agent',
+    (pathname) => {
+      expect(isProbeRequest('kube-probe/1.29', pathname)).toBe(false);
+    },
+  );
 });
 
 describe('formatLoggedPath', () => {
@@ -85,6 +93,12 @@ describe('parseMemoryThresholdsMb', () => {
 });
 
 describe('createMemoryWatermark', () => {
+  it('reports the highest crossed threshold regardless of caller ordering', () => {
+    const watermark = createMemoryWatermark([448, 256, 384]);
+
+    expect(watermark.check(500 * MIB)).toBe(448);
+  });
+
   it('fires once per upward crossing and reports the highest threshold crossed', () => {
     const watermark = createMemoryWatermark([256, 384, 448]);
     expect(watermark.check(100 * MIB)).toBeNull();
@@ -106,5 +120,55 @@ describe('createMemoryWatermark', () => {
     expect(watermark.check(101 * MIB)).toBeNull();
     expect(watermark.check(102 * MIB)).toBeNull();
     expect(watermark.check(101 * MIB)).toBeNull();
+  });
+});
+
+describe('reportOnBodyComplete', () => {
+  it('reports immediately for a bodyless response', () => {
+    const outcomes: string[] = [];
+    const res = reportOnBodyComplete(new Response(null, { status: 204 }), (o) => outcomes.push(o));
+
+    expect(outcomes).toEqual(['ok']);
+    expect(res.status).toBe(204);
+  });
+
+  it('waits for the stream to drain before reporting success', async () => {
+    const outcomes: string[] = [];
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('chunk'));
+        controller.close();
+      },
+    });
+
+    const res = reportOnBodyComplete(new Response(body, { status: 200 }), (o) => outcomes.push(o));
+    expect(outcomes).toEqual([]);
+
+    await res.text();
+    expect(outcomes).toEqual(['ok']);
+  });
+
+  it('reports a stream error when the upstream body fails mid-transfer', async () => {
+    const outcomes: string[] = [];
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('partial'));
+        controller.error(new Error('upstream died'));
+      },
+    });
+
+    const res = reportOnBodyComplete(new Response(body, { status: 200 }), (o) => outcomes.push(o));
+    await expect(res.text()).rejects.toThrow();
+    expect(outcomes).toEqual(['stream-error']);
+  });
+
+  it('preserves status and headers', () => {
+    const res = reportOnBodyComplete(
+      new Response('csv', { status: 200, headers: { 'content-type': 'text/csv' } }),
+      () => {},
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('text/csv');
   });
 });

--- a/src/server/logging.test.ts
+++ b/src/server/logging.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isProbeRequest,
+  createFloodGuard,
+  formatLoggedPath,
+  createMemoryWatermark,
+  parseMemoryThresholdsMb,
+} from './logging';
+
+const MIB = 1024 * 1024;
+
+describe('isProbeRequest', () => {
+  it.each([
+    ['kube-probe/1.29', true],
+    ['kube-probe/1.31+', true],
+    ['Mozilla/5.0 (Macintosh)', false],
+    ['curl/8.7.1', false],
+    ['', false],
+    [null, false],
+  ])('user-agent %s -> %s', (userAgent, expected) => {
+    expect(isProbeRequest(userAgent)).toBe(expected);
+  });
+});
+
+describe('formatLoggedPath', () => {
+  it('passes short paths through unchanged', () => {
+    expect(formatLoggedPath('/auth/openid/callback')).toBe('/auth/openid/callback');
+  });
+
+  it('truncates paths beyond 200 characters', () => {
+    const long = `/${'a'.repeat(500)}`;
+    const formatted = formatLoggedPath(long);
+    expect(formatted).toBe(`${long.slice(0, 200)}...(truncated)`);
+  });
+
+  it('keeps a path of exactly 200 characters intact', () => {
+    const exact = `/${'a'.repeat(199)}`;
+    expect(formatLoggedPath(exact)).toBe(exact);
+  });
+});
+
+describe('createFloodGuard', () => {
+  it('admits requests up to the cap within one window', () => {
+    const guard = createFloodGuard(3, 10_000);
+    expect(guard.admit(1_000).admitted).toBe(true);
+    expect(guard.admit(2_000).admitted).toBe(true);
+    expect(guard.admit(3_000).admitted).toBe(true);
+    expect(guard.admit(4_000).admitted).toBe(false);
+    expect(guard.admit(5_000).admitted).toBe(false);
+  });
+
+  it('reports the suppressed count once when a new window opens', () => {
+    const guard = createFloodGuard(2, 10_000);
+    guard.admit(1_000);
+    guard.admit(2_000);
+    guard.admit(3_000);
+    guard.admit(4_000);
+    const next = guard.admit(12_000);
+    expect(next.admitted).toBe(true);
+    expect(next.suppressedInPriorWindow).toBe(2);
+    expect(guard.admit(13_000).suppressedInPriorWindow).toBe(0);
+  });
+
+  it('resets the admission budget each window', () => {
+    const guard = createFloodGuard(1, 10_000);
+    expect(guard.admit(0).admitted).toBe(true);
+    expect(guard.admit(1).admitted).toBe(false);
+    expect(guard.admit(10_000).admitted).toBe(true);
+    expect(guard.admit(10_001).admitted).toBe(false);
+  });
+});
+
+describe('parseMemoryThresholdsMb', () => {
+  it.each([
+    [undefined, [256, 384, 448]],
+    ['', [256, 384, 448]],
+    ['100,200,300', [100, 200, 300]],
+    ['300, 100, 200', [100, 200, 300]],
+    ['512', [512]],
+    ['abc,-5,0', [256, 384, 448]],
+    ['abc,128', [128]],
+  ])('parses %s -> %s', (raw, expected) => {
+    expect(parseMemoryThresholdsMb(raw)).toEqual(expected);
+  });
+});
+
+describe('createMemoryWatermark', () => {
+  it('fires once per upward crossing and reports the highest threshold crossed', () => {
+    const watermark = createMemoryWatermark([256, 384, 448]);
+    expect(watermark.check(100 * MIB)).toBeNull();
+    expect(watermark.check(260 * MIB)).toBe(256);
+    expect(watermark.check(270 * MIB)).toBeNull();
+    expect(watermark.check(460 * MIB)).toBe(448);
+  });
+
+  it('re-arms a threshold after memory drops back below it', () => {
+    const watermark = createMemoryWatermark([256]);
+    expect(watermark.check(300 * MIB)).toBe(256);
+    expect(watermark.check(310 * MIB)).toBeNull();
+    expect(watermark.check(200 * MIB)).toBeNull();
+    expect(watermark.check(300 * MIB)).toBe(256);
+  });
+
+  it('stays silent while memory remains flat below every threshold', () => {
+    const watermark = createMemoryWatermark([256, 384, 448]);
+    expect(watermark.check(101 * MIB)).toBeNull();
+    expect(watermark.check(102 * MIB)).toBeNull();
+    expect(watermark.check(101 * MIB)).toBeNull();
+  });
+});

--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -105,6 +105,13 @@ export function reportOnBodyComplete(
     return res;
   }
 
+  let reported = false;
+  const reportOnce = (outcome: 'ok' | 'stream-error'): void => {
+    if (reported) return;
+    reported = true;
+    report(outcome);
+  };
+
   const source = res.body.getReader();
   const monitored = new ReadableStream<Uint8Array>({
     async pull(controller) {
@@ -112,17 +119,18 @@ export function reportOnBodyComplete(
         const { done, value } = await source.read();
         if (done) {
           controller.close();
-          report('ok');
+          reportOnce('ok');
           return;
         }
         controller.enqueue(value);
       } catch (err) {
         controller.error(err);
-        report('stream-error');
+        reportOnce('stream-error');
       }
     },
     cancel(reason) {
-      report('stream-error');
+      /** A cancel races any in-flight read, whose rejection would otherwise report a second time. */
+      reportOnce('stream-error');
       return source.cancel(reason);
     },
   });

--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -1,11 +1,20 @@
+import type * as t from '@/types';
 const MAX_LOGGED_PATH_LENGTH = 200;
 const DEFAULT_MEMORY_THRESHOLDS_MB = [256, 384, 448];
 
 export const FLOOD_WINDOW_MS = 10_000;
 export const FLOOD_MAX_REQUESTS = 200;
 
-/** Kubelet health probes identify themselves via User-Agent; logging them would drown real traffic. */
-export function isProbeRequest(userAgent: string | null): boolean {
+/** Paths a kubelet probe is allowed to reach; anything else must stay loggable. */
+const PROBE_PATHS = new Set(['/health']);
+
+/**
+ * Kubelet health probes identify themselves via User-Agent, but that header is
+ * client-controlled, so the path is required too. Without it any request could
+ * claim to be a probe and suppress its own arrival and completion lines.
+ */
+export function isProbeRequest(userAgent: string | null, pathname: string): boolean {
+  if (!PROBE_PATHS.has(pathname)) return false;
   return userAgent !== null && userAgent.startsWith('kube-probe/');
 }
 
@@ -13,15 +22,6 @@ export function isProbeRequest(userAgent: string | null): boolean {
 export function formatLoggedPath(pathname: string): string {
   if (pathname.length <= MAX_LOGGED_PATH_LENGTH) return pathname;
   return `${pathname.slice(0, MAX_LOGGED_PATH_LENGTH)}...(truncated)`;
-}
-
-export interface FloodGuardDecision {
-  admitted: boolean;
-  suppressedInPriorWindow: number;
-}
-
-export interface FloodGuard {
-  admit: (nowMs: number) => FloodGuardDecision;
 }
 
 /**
@@ -32,13 +32,13 @@ export interface FloodGuard {
 export function createFloodGuard(
   maxRequests: number = FLOOD_MAX_REQUESTS,
   windowMs: number = FLOOD_WINDOW_MS,
-): FloodGuard {
+): t.FloodGuard {
   let windowStart = 0;
   let admittedInWindow = 0;
   let suppressedInWindow = 0;
 
   return {
-    admit(nowMs: number): FloodGuardDecision {
+    admit(nowMs: number): t.FloodGuardDecision {
       let suppressedInPriorWindow = 0;
       if (nowMs - windowStart >= windowMs) {
         suppressedInPriorWindow = suppressedInWindow;
@@ -66,11 +66,6 @@ export function parseMemoryThresholdsMb(raw: string | undefined): number[] {
   return [...parsed].sort((a, b) => a - b);
 }
 
-export interface MemoryWatermark {
-  /** Returns the highest threshold (in MiB) newly crossed upward, or null. */
-  check: (rssBytes: number) => number | null;
-}
-
 const BYTES_PER_MIB = 1024 * 1024;
 
 /**
@@ -78,7 +73,7 @@ const BYTES_PER_MIB = 1024 * 1024;
  * RSS drops back below it, so a sawtooth pattern logs each climb without
  * repeating on every tick spent above a threshold.
  */
-export function createMemoryWatermark(thresholdsMb: number[]): MemoryWatermark {
+export function createMemoryWatermark(thresholdsMb: number[]): t.MemoryWatermark {
   let lastRssMb = 0;
 
   return {
@@ -86,10 +81,55 @@ export function createMemoryWatermark(thresholdsMb: number[]): MemoryWatermark {
       const rssMb = rssBytes / BYTES_PER_MIB;
       let crossed: number | null = null;
       for (const threshold of thresholdsMb) {
-        if (lastRssMb < threshold && rssMb >= threshold) crossed = threshold;
+        if (lastRssMb >= threshold || rssMb < threshold) continue;
+        if (crossed === null || threshold > crossed) crossed = threshold;
       }
       lastRssMb = rssMb;
       return crossed;
     },
   };
+}
+
+/**
+ * Wraps a streaming body so completion is reported once the bytes are actually
+ * delivered. A handler that returns a `Response` built from an upstream stream
+ * resolves before transfer, so logging at that point would claim success for a
+ * transfer that can still fail mid-flight.
+ */
+export function reportOnBodyComplete(
+  res: Response,
+  report: (outcome: 'ok' | 'stream-error') => void,
+): Response {
+  if (res.body === null) {
+    report('ok');
+    return res;
+  }
+
+  const source = res.body.getReader();
+  const monitored = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await source.read();
+        if (done) {
+          controller.close();
+          report('ok');
+          return;
+        }
+        controller.enqueue(value);
+      } catch (err) {
+        controller.error(err);
+        report('stream-error');
+      }
+    },
+    cancel(reason) {
+      report('stream-error');
+      return source.cancel(reason);
+    },
+  });
+
+  return new Response(monitored, {
+    status: res.status,
+    statusText: res.statusText,
+    headers: res.headers,
+  });
 }

--- a/src/server/logging.ts
+++ b/src/server/logging.ts
@@ -1,0 +1,95 @@
+const MAX_LOGGED_PATH_LENGTH = 200;
+const DEFAULT_MEMORY_THRESHOLDS_MB = [256, 384, 448];
+
+export const FLOOD_WINDOW_MS = 10_000;
+export const FLOOD_MAX_REQUESTS = 200;
+
+/** Kubelet health probes identify themselves via User-Agent; logging them would drown real traffic. */
+export function isProbeRequest(userAgent: string | null): boolean {
+  return userAgent !== null && userAgent.startsWith('kube-probe/');
+}
+
+/** Never logs query strings (they can carry OAuth exchange codes); caps length against scanner URLs. */
+export function formatLoggedPath(pathname: string): string {
+  if (pathname.length <= MAX_LOGGED_PATH_LENGTH) return pathname;
+  return `${pathname.slice(0, MAX_LOGGED_PATH_LENGTH)}...(truncated)`;
+}
+
+export interface FloodGuardDecision {
+  admitted: boolean;
+  suppressedInPriorWindow: number;
+}
+
+export interface FloodGuard {
+  admit: (nowMs: number) => FloodGuardDecision;
+}
+
+/**
+ * Caps logged requests per fixed window so a request flood can't amplify into
+ * a log flood; the count of suppressed requests is surfaced once when the
+ * next window opens, so the flood itself stays visible.
+ */
+export function createFloodGuard(
+  maxRequests: number = FLOOD_MAX_REQUESTS,
+  windowMs: number = FLOOD_WINDOW_MS,
+): FloodGuard {
+  let windowStart = 0;
+  let admittedInWindow = 0;
+  let suppressedInWindow = 0;
+
+  return {
+    admit(nowMs: number): FloodGuardDecision {
+      let suppressedInPriorWindow = 0;
+      if (nowMs - windowStart >= windowMs) {
+        suppressedInPriorWindow = suppressedInWindow;
+        windowStart = nowMs;
+        admittedInWindow = 0;
+        suppressedInWindow = 0;
+      }
+      if (admittedInWindow < maxRequests) {
+        admittedInWindow += 1;
+        return { admitted: true, suppressedInPriorWindow };
+      }
+      suppressedInWindow += 1;
+      return { admitted: false, suppressedInPriorWindow };
+    },
+  };
+}
+
+export function parseMemoryThresholdsMb(raw: string | undefined): number[] {
+  if (!raw) return DEFAULT_MEMORY_THRESHOLDS_MB;
+  const parsed = raw
+    .split(',')
+    .map((value) => Number(value.trim()))
+    .filter((value) => Number.isFinite(value) && value > 0);
+  if (parsed.length === 0) return DEFAULT_MEMORY_THRESHOLDS_MB;
+  return [...parsed].sort((a, b) => a - b);
+}
+
+export interface MemoryWatermark {
+  /** Returns the highest threshold (in MiB) newly crossed upward, or null. */
+  check: (rssBytes: number) => number | null;
+}
+
+const BYTES_PER_MIB = 1024 * 1024;
+
+/**
+ * Fires once per upward crossing of each threshold; a threshold re-arms when
+ * RSS drops back below it, so a sawtooth pattern logs each climb without
+ * repeating on every tick spent above a threshold.
+ */
+export function createMemoryWatermark(thresholdsMb: number[]): MemoryWatermark {
+  let lastRssMb = 0;
+
+  return {
+    check(rssBytes: number): number | null {
+      const rssMb = rssBytes / BYTES_PER_MIB;
+      let crossed: number | null = null;
+      for (const threshold of thresholdsMb) {
+        if (lastRssMb < threshold && rssMb >= threshold) crossed = threshold;
+      }
+      lastRssMb = rssMb;
+      return crossed;
+    },
+  };
+}

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -36,3 +36,17 @@ export interface OAuthExchangeResponse {
   user: SerializableUser;
   expiresAt?: number;
 }
+
+export interface FloodGuardDecision {
+  admitted: boolean;
+  suppressedInPriorWindow: number;
+}
+
+export interface FloodGuard {
+  admit: (nowMs: number) => FloodGuardDecision;
+}
+
+export interface MemoryWatermark {
+  /** Returns the highest threshold (in MiB) newly crossed upward, or null. */
+  check: (rssBytes: number) => number | null;
+}


### PR DESCRIPTION
## Summary

The bun server's only log output is its two startup lines, which leaves crashes and OOMKills undiagnosable: the HTTP metrics increment on *completion*, so a request that kills the process mid-flight is invisible to them, an uncaught handler throw produces no output at all, and nothing captures memory growth between metric scrapes.

Adds three narrow instruments to the serve path (`server.ts`, pure helpers in `src/server/logging.ts`):

- **Request tombstones** — `[req] GET /path` at arrival (before the handler runs, so a fatal request leaves its method and path as the process's last words) plus `[req] GET /path 200 12ms` on completion. An arrival line with no matching completion identifies the request a process died holding. Paths log without query strings (they can carry OAuth exchange codes) and truncate at 200 chars. Kubelet probes (`kube-probe/` user-agent) are skipped so steady-state logs stay near-silent. A per-window cap (200 requests / 10s) stops a request flood from amplifying into a log flood, surfacing `[req] suppressed N requests in prior window` instead.
- **Memory watermarks** — a 10s tick logs `[mem] rss=391Mi heapUsed=213Mi (crossed 384Mi)` on each upward threshold crossing (defaults 256/384/448 MiB, configurable via `ADMIN_PANEL_MEMORY_LOG_THRESHOLDS_MB`), re-arming when memory drops back below a threshold. This timestamps allocation bursts even when no request is in flight — the deciding evidence between a pathological request and runtime GC behavior.
- **Error hook** — `Bun.serve` had no `error()` handler, so an uncaught throw in the SSR handler produced no log line at all. It now logs the message and stack and returns a plain 500.

On by default; disable with `ADMIN_PANEL_REQUEST_LOG=false`. Prometheus metrics, `/metrics`, and `/health` behavior unchanged.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

22 new unit tests (probe detection, truncation, flood-guard windows, watermark hysteresis); full suite (821 tests) passing; `tsc --noEmit`, `eslint`, and a from-scratch production build clean.

Verified live against the production build (`bun run build` + `bun run start`):
- `GET /login?redirect=/...` logs as `[req] GET /login` — query string never appears
- `kube-probe/1.29` requests produce zero lines
- a 300-char path truncates at 200 with a `...(truncated)` marker
- a 230-request burst logs exactly 200 requests, then `[req] suppressed 30 requests in prior window` when the next window opens
- watermark fires on threshold crossing with env-configured thresholds and reports the highest threshold crossed
- `ADMIN_PANEL_REQUEST_LOG=false` produces zero request lines under real traffic

### **Test Configuration**:

- Bun 1.3.11, production build served locally with `SESSION_SECRET` set
- Watermark exercised via `ADMIN_PANEL_MEMORY_LOG_THRESHOLDS_MB=50,80` so thresholds sit below the server's baseline RSS

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes