### PR TITLE
fix(admin): recover from non-admin organization

### DIFF
--- a/src/components/shared/AccessDenied.tsx
+++ b/src/components/shared/AccessDenied.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@clickhouse/click-ui';
-import { Link } from '@tanstack/react-router';
 import { useLocalize } from '@/hooks';
+import { getLibreChatUrl } from '@/server/utils/url';
+import { OrganizationSwitcher } from './OrganizationSwitcher';
 
 export function AccessDenied() {
   const localize = useLocalize();
@@ -18,12 +19,13 @@ export function AccessDenied() {
       <p className="max-w-md text-center text-sm text-(--cui-color-text-muted)">
         {localize('com_access_denied_description')}
       </p>
-      <Link
-        to="/configuration"
+      <OrganizationSwitcher />
+      <a
+        href={getLibreChatUrl()}
         className="mt-2 rounded-lg border border-(--cui-color-stroke-default) bg-transparent px-4 py-2 text-sm font-medium text-(--cui-color-text-default) no-underline transition-colors hover:bg-(--cui-color-background-hover)"
       >
-        {localize('com_nav_go_home')}
-      </Link>
+        {localize('com_admin_return_to_librechat')}
+      </a>
     </div>
   );
 }

--- a/src/components/shared/OrganizationSwitcher.tsx
+++ b/src/components/shared/OrganizationSwitcher.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { Select } from '@clickhouse/click-ui';
+import { useLocalize } from '@/hooks';
+import { adminOrganizationsQueryOptions, switchAdminOrganizationFn } from '@/server';
+
+export function OrganizationSwitcher() {
+  const localize = useLocalize();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [selectedOrgId, setSelectedOrgId] = useState('');
+  const organizationsQuery = useQuery(adminOrganizationsQueryOptions);
+  const switchMutation = useMutation({
+    mutationFn: (targetOrgId: string) => switchAdminOrganizationFn({ data: { targetOrgId } }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['adminOrganizations'] });
+      await router.invalidate();
+      await router.navigate({ to: '/' });
+    },
+    onError: () => setSelectedOrgId(''),
+  });
+
+  const organizations = organizationsQuery.data ?? [];
+  if (organizations.length === 0) return null;
+
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-2">
+      <Select
+        label={localize('com_admin_org_switcher_label')}
+        placeholder={localize('com_admin_org_switcher_placeholder')}
+        value={selectedOrgId}
+        onSelect={(value) => {
+          setSelectedOrgId(value);
+          switchMutation.mutate(value);
+        }}
+        disabled={switchMutation.isPending || organizationsQuery.isLoading}
+      >
+        {organizations.map((organization) => (
+          <Select.Item key={organization.id} value={organization.id}>
+            {organization.name}
+          </Select.Item>
+        ))}
+      </Select>
+      {switchMutation.isPending && (
+        <p className="text-sm text-(--cui-color-text-muted)">
+          {localize('com_admin_org_switcher_switching')}
+        </p>
+      )}
+      {switchMutation.isError && (
+        <p role="alert" className="text-sm text-(--cui-color-text-danger)">
+          {localize('com_admin_org_switcher_error')}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -5,6 +5,7 @@ export { EditButton } from './EditButton';
 export { EmptyState } from './EmptyState';
 export { FormDialog } from './FormDialog';
 export { KebabMenu } from './KebabMenu';
+export { OrganizationSwitcher } from './OrganizationSwitcher';
 export { LoadingState } from './LoadingState';
 export { Pagination } from './Pagination';
 export { PermissionsUnavailable } from './PermissionsUnavailable';

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1228,5 +1228,10 @@
   "com_kv_type_number": "123",
   "com_kv_type_boolean": "T/F",
   "com_kv_type_json": "{ }",
-  "com_a11y_logo_alt": "LibreChat logo"
+  "com_a11y_logo_alt": "LibreChat logo",
+  "com_admin_return_to_librechat": "Return to LibreChat",
+  "com_admin_org_switcher_label": "Choose an organization where you have admin access",
+  "com_admin_org_switcher_placeholder": "Select an organization",
+  "com_admin_org_switcher_switching": "Switching organization...",
+  "com_admin_org_switcher_error": "We couldn't switch organizations. Please try again."
 }

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -207,8 +207,8 @@ export const verifyAdminTokenFn = createServerFn({ method: 'GET' }).handler(asyn
 
         if (!response.ok) {
           if (response.status === 403) {
-            await clearSession(session);
-            return { valid: false, error: 'Admin privileges have been revoked' };
+            await session.update({ lastVerified: now, lastActivity: now });
+            return { valid: true, user, accessDenied: true };
           }
           if (response.status === 401) {
             if (refreshToken) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,7 @@ export * from './auth';
 export * from './capabilities';
 export * from './config';
 export * from './groups';
+export * from './organizations';
 export * from './roles';
 export * from './scopes';
 export * from './users';

--- a/src/server/organizations.ts
+++ b/src/server/organizations.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import { queryOptions } from '@tanstack/react-query';
+import { createServerFn } from '@tanstack/react-start';
+import type * as t from '@/types';
+import { apiFetch, extractApiError } from './utils/api';
+import { useAppSession } from './session';
+
+export const getAdminOrganizationsFn = createServerFn({ method: 'GET' }).handler(
+  async (): Promise<{ orgs: t.AdminOrganization[] }> => {
+    const response = await apiFetch('/api/admin/orgs');
+    if (!response.ok) {
+      await extractApiError(response, 'Failed to fetch organizations');
+    }
+    return (await response.json()) as { orgs: t.AdminOrganization[] };
+  },
+);
+
+export const adminOrganizationsQueryOptions = queryOptions({
+  queryKey: ['adminOrganizations'],
+  queryFn: () => getAdminOrganizationsFn().then((response) => response.orgs),
+  staleTime: 30_000,
+  retry: false,
+});
+
+export const switchAdminOrganizationFn = createServerFn({ method: 'POST' })
+  .inputValidator(z.object({ targetOrgId: z.string().min(1) }))
+  .handler(async ({ data }): Promise<{ user: t.SerializableUser }> => {
+    const response = await apiFetch('/api/admin/orgs/switch', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) {
+      await extractApiError(response, 'Failed to switch organization');
+    }
+
+    const result = (await response.json()) as {
+      token: string;
+      user: t.SerializableUser;
+    };
+    const session = await useAppSession();
+    const now = Date.now();
+    await session.update({
+      user: result.user,
+      token: result.token,
+      expiresAt: undefined,
+      lastVerified: now,
+      lastActivity: now,
+    });
+
+    return { user: result.user };
+  });

--- a/src/server/utils/url.ts
+++ b/src/server/utils/url.ts
@@ -8,6 +8,16 @@ export function getApiBaseUrl(): string {
   return 'http://localhost:3080';
 }
 
+export function getLibreChatUrl(): string {
+  if (typeof process !== 'undefined' && process.env?.VITE_LIBRECHAT_URL) {
+    return process.env.VITE_LIBRECHAT_URL;
+  }
+  if (typeof import.meta !== 'undefined' && import.meta.env?.VITE_LIBRECHAT_URL) {
+    return import.meta.env.VITE_LIBRECHAT_URL;
+  }
+  return getApiBaseUrl();
+}
+
 /** Server-to-server API URL. Falls back to getApiBaseUrl() if API_SERVER_URL is not set. */
 export function getServerApiUrl(): string {
   if (typeof process !== 'undefined' && process.env?.API_SERVER_URL) {

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -30,6 +30,12 @@ export interface AdminVerifyResponse {
   user: SerializableUser;
 }
 
+export interface AdminOrganization {
+  id: string;
+  name: string;
+  isCurrent: boolean;
+}
+
 export interface OAuthExchangeResponse {
   token: string;
   refreshToken?: string;


### PR DESCRIPTION
## Summary

- Preserve an authenticated session when the current org returns a tenant-scoped admin denial.
- Add a recovery view with a configured LibreChat return link.
- Add an organization selector that can list and switch only to orgs the actor administers.
- Persist the newly minted target-org admin session and reload the panel after switching.

This implements the panel half of Linear [AI-1663](https://linear.app/clickhouse/issue/AI-1663/fixadmin-panel-recover-from-non-admin-org-without-login-redirect-loop).

## Backend dependency

The recovery UI uses the coordinated backend contract in [ClickHouse/LibreChat#328](https://github.com/ClickHouse/LibreChat/pull/328):

- authenticated OpenID handoff may complete for a non-admin current org;
- `GET /api/admin/orgs` returns only `cpContext.adminOrgIds`;
- `POST /api/admin/orgs/switch` retains the explicit target-org admin check.

## Verification

- `git diff --check`
- JSON validation for `src/locales/en/translation.json`

The isolated panel worktree has no installed dependencies. The attempted dependency installation was interrupted, so panel lint, tests, and build remain for CI/local dependency-backed verification.