### PR TITLE
🐛 fix: Resolve Admin Capability Gate In Route Loader

### DIFF
--- a/src/hooks/useCapabilities.ts
+++ b/src/hooks/useCapabilities.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { getRouteApi } from '@tanstack/react-router';
 import { queryOptions, useQuery } from '@tanstack/react-query';
+import type * as t from '@/types';
 import { getEffectiveCapabilitiesFn } from '@/server';
 import { hasImpliedCapability } from '@/constants';
 
@@ -11,15 +12,10 @@ const GRANTS_UNAVAILABLE_PATTERN = /\b(404|503)\b|endpoint not found|fetch faile
 const AUTH_DENIED_PATTERN =
   /\b(401|403)\b|forbidden|unauthorized|authentication required|no admin session token/i;
 
-interface CapabilitiesData {
-  available: boolean;
-  capabilities: string[];
-}
-
 export const capabilitiesQueryOptions = (userId: string) =>
   queryOptions({
     queryKey: ['effectiveCapabilities', userId],
-    queryFn: async (): Promise<CapabilitiesData> => {
+    queryFn: async (): Promise<t.CapabilitiesData> => {
       try {
         const res = await getEffectiveCapabilitiesFn();
         return { available: true, capabilities: res.capabilities };

--- a/src/hooks/useCapabilities.ts
+++ b/src/hooks/useCapabilities.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
+import { queryOptions, useQuery } from '@tanstack/react-query';
 import { getEffectiveCapabilitiesFn } from '@/server';
 import { hasImpliedCapability } from '@/constants';
 
@@ -11,26 +11,25 @@ const GRANTS_UNAVAILABLE_PATTERN = /\b(404|503)\b|endpoint not found|fetch faile
 const AUTH_DENIED_PATTERN =
   /\b(401|403)\b|forbidden|unauthorized|authentication required|no admin session token/i;
 
-export function useCapabilities(): {
+interface CapabilitiesData {
+  available: boolean;
   capabilities: string[];
-  hasCapability: (cap: string) => boolean;
-  isLoading: boolean;
-  isError: boolean;
-} {
-  const { user } = Route.useRouteContext();
-  const query = useQuery({
-    queryKey: ['effectiveCapabilities', user?.id ?? ''],
-    queryFn: async () => {
+}
+
+export const capabilitiesQueryOptions = (userId: string) =>
+  queryOptions({
+    queryKey: ['effectiveCapabilities', userId],
+    queryFn: async (): Promise<CapabilitiesData> => {
       try {
         const res = await getEffectiveCapabilitiesFn();
         return { available: true, capabilities: res.capabilities };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         if (GRANTS_UNAVAILABLE_PATTERN.test(message)) {
-          return { available: false, capabilities: [] as string[] };
+          return { available: false, capabilities: [] };
         }
         if (AUTH_DENIED_PATTERN.test(message)) {
-          return { available: true, capabilities: [] as string[] };
+          return { available: true, capabilities: [] };
         }
         throw err;
       }
@@ -38,6 +37,15 @@ export function useCapabilities(): {
     staleTime: 30_000,
     retry: false,
   });
+
+export function useCapabilities(): {
+  capabilities: string[];
+  hasCapability: (cap: string) => boolean;
+  isLoading: boolean;
+  isError: boolean;
+} {
+  const { user } = Route.useRouteContext();
+  const query = useQuery(capabilitiesQueryOptions(user?.id ?? ''));
 
   const grantsAvailable = query.data?.available ?? false;
   const capabilities = query.data?.capabilities ?? [];

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,9 +9,10 @@ import {
   Outlet,
   ScriptOnce,
   Scripts,
-  createRootRoute,
+  createRootRouteWithContext,
 } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
+import type { QueryClient } from '@tanstack/react-query';
 import { ThemeProvider, useTheme } from '../contexts/ThemeContext';
 import appCss from '../styles.css?url';
 import { useLocalize } from '@/hooks';
@@ -24,7 +25,7 @@ const themeScript = `(function(){
   } catch(e) {}
 })();`;
 
-export const Route = createRootRoute({
+export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()({
   ssr: false,
   head: () => ({
     meta: [

--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -1,13 +1,14 @@
 import { useState, useEffect } from 'react';
 import { Icon } from '@clickhouse/click-ui';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Outlet, useRouter, Link, redirect } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
-import { useCapabilities, useCommandMenu, useLocalize } from '@/hooks';
-import { CommandMenu } from '@/components/CommandMenu';
-import { AccessDenied } from '@/components/shared';
-import { SystemCapabilities } from '@/constants';
-import { Sidebar } from '@/components/Sidebar';
+import { capabilitiesQueryOptions, useCommandMenu, useLocalize } from '@/hooks';
 import { verifyAdminTokenFn } from '@/server';
+import { SystemCapabilities, hasImpliedCapability } from '@/constants';
+import { AccessDenied, LoadingState } from '@/components/shared';
+import { CommandMenu } from '@/components/CommandMenu';
+import { Sidebar } from '@/components/Sidebar';
 import { Header } from '@/components/Header';
 
 const ROUTE_TITLE_KEYS: Record<string, string> = {
@@ -18,7 +19,6 @@ const ROUTE_TITLE_KEYS: Record<string, string> = {
   '/grants': 'com_grants_title',
   '/help': 'com_help_title',
 };
-
 
 export const Route = createFileRoute('/_app')({
   beforeLoad: async ({ location }) => {
@@ -33,14 +33,26 @@ export const Route = createFileRoute('/_app')({
 
     return { user: result.user };
   },
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(capabilitiesQueryOptions(context.user.id));
+  },
+  pendingComponent: AppPending,
   component: AppLayout,
   errorComponent: AppError,
   notFoundComponent: AppNotFound,
 });
 
+function AppPending() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <LoadingState />
+    </div>
+  );
+}
+
 function AppLayout() {
   const { user } = Route.useRouteContext();
-  const { hasCapability, isLoading, isError } = useCapabilities();
+  const { available, capabilities } = useSuspenseQuery(capabilitiesQueryOptions(user.id)).data;
   const router = useRouter();
   const localize = useLocalize();
   const { open, setOpen } = useCommandMenu();
@@ -68,7 +80,7 @@ function AppLayout() {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  if (!isLoading && !isError && !hasCapability(SystemCapabilities.ACCESS_ADMIN)) {
+  if (!available || !hasImpliedCapability(capabilities, SystemCapabilities.ACCESS_ADMIN)) {
     return <AccessDenied />;
   }
 

--- a/src/server/capabilities.ts
+++ b/src/server/capabilities.ts
@@ -163,13 +163,6 @@ export async function requireAllSectionCapabilities(sections: string[]): Promise
   }
 }
 
-export const effectiveCapabilitiesOptions = (userId: string) =>
-  queryOptions<string[]>({
-    queryKey: ['effectiveCapabilities', userId],
-    queryFn: () => getEffectiveCapabilitiesFn().then((r) => r.capabilities),
-    staleTime: 30_000,
-  });
-
 // ── Mutations ────────────────────────────────────────────────────────
 
 export const grantCapabilityFn = createServerFn({ method: 'POST' })

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -13,6 +13,11 @@ export type LocalizeFn = (key: string, options?: Record<string, string | number>
 
 export type TranslationKeys = string;
 
+export interface CapabilitiesData {
+  available: boolean;
+  capabilities: string[];
+}
+
 export interface UseProfileMutationsOptions {
   fieldPath: string;
   onProfileChange?: () => void;


### PR DESCRIPTION
## Summary

`AppLayout` decided admin access from a component-level query, so while `/api/admin/grants/effective` was in flight the layout fell through and rendered the full panel (sidebar, header, dashboard) before replacing it with the access-denied screen. A non-admin briefly sees the entire admin UI, including its navigation.

This resolves the capability check in the `_app` route loader with `queryClient.ensureQueryData` and reads it in the component with `useSuspenseQuery`, so the layout only ever renders a decided state: authorized or denied. The route's `pendingComponent` covers the wait. This is the pattern TanStack documents for data-derived route gating, for exactly this reason ("No flash of loading states").

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## What changed

- `useCapabilities.ts` exports a `capabilitiesQueryOptions(userId)` factory so the loader and the hook share one query definition and one cache entry. The hook's signature and all existing consumers are unchanged.
- `_app.tsx` prefetches that query in `loader`, renders `AppPending` while it resolves, and derives the admin decision synchronously via `useSuspenseQuery`. The `isLoading`/`isError` fall-through is gone.
- `__root.tsx` uses `createRootRouteWithContext<{ queryClient }>` so the loader can reach the query client through route context. The router already supplies it; only the type was missing.
- Removes `effectiveCapabilitiesOptions` from `server/capabilities.ts`. It had no callers anywhere in the repo, and it declared the same `['effectiveCapabilities', userId]` cache key as the hook with an incompatible payload (`string[]` versus `{ available, capabilities }`) and no 401/403/404 classification. Leaving both would mean whichever populated the key first won, and a consumer of the other would read the wrong shape.

## Testing

Verified in a container against a mock of the admin API, driving the real panel through a genuine login. Because the flash is a sub-frame DOM transition, a `MutationObserver` installed before any app JS runs timestamps the first appearance of each marker; screenshots and polling are too coarse to catch it.

Before, on this branch's base, at real timing (no artificial latency):

```
Loading...                                        611ms
Welcome! / Quick links / Getting around / Ctrl+K   1105ms   <- full panel mounted
Access denied                                     1147ms
```

The panel is on screen for ~42ms for a user who is about to be denied.

**Before: the full panel mounts while capabilities load, then is replaced by the access-denied screen.**

[clip-base-flash.webm](https://github.com/user-attachments/assets/f3c9acb4-77e4-425f-9653-ddb618c4f8ba)

This clip was captured on a branch that also changes the access-denied screen itself, so its final frame differs from what `main` renders. The flashing panel is the same code path this PR fixes.

After, same harness:

```
Loading...     646ms
Access denied  1142ms
CHROME_MARKERS=[]
```

No privileged chrome enters the DOM at any point.

**After: neutral loading only, then the access-denied screen.**

<img width="1280" height="720" alt="02-flash-after" src="https://github.com/user-attachments/assets/c3deb6d9-a65e-49e5-8a60-5f884384f7e5" />

Local gates: `eslint` clean on the changed files, `prettier --check` clean, `tsc --noEmit` clean, and the full `vitest` suite passes.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
