### PR TITLE
ci: add Dependabot config for bun, GitHub Actions, and Docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 1,15 * *"


### PR DESCRIPTION
## Summary

Adds a `.github/dependabot.yml` so Dependabot opens update PRs twice a month (1st and 15th, via a cron schedule, since Dependabot has no native biweekly interval) for the three ecosystems in this repo: bun dependencies (`package.json` / `bun.lock`), GitHub Actions used in `ci.yml` and `docker-publish.yml`, and the `Dockerfile` base image.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Validated the YAML parses and checked the cron syntax (`interval: "cron"` + `cronjob`) against the dependabot-2.0 JSON schema. The config takes effect once merged to the default branch; runs will appear under Insights → Dependency graph → Dependabot.

### **Test Configuration**:

Not applicable, CI configuration only.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings