### PR TITLE
🐛 fix: Include Nested Paths in Config Validation Errors

### DIFF
--- a/src/server/config.test.ts
+++ b/src/server/config.test.ts
@@ -1330,6 +1330,18 @@ describe('validateFieldValue for endpoints', () => {
     expect(result).toEqual({ success: true });
   });
 
+  it('includes the full path for nested array validation errors', () => {
+    const result = validateFieldValue('endpoints.custom', [
+      validEndpoint,
+      { ...validEndpoint, models: { fetch: true } },
+    ]);
+
+    expect(result).toEqual({
+      success: false,
+      error: 'endpoints.custom[1].models.default: Required',
+    });
+  });
+
   it('gracefully handles unknown deep paths', () => {
     const result = validateFieldValue('endpoints.custom.0.nonexistent.deep', 'value');
     expect(result).toEqual({ success: true });

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -625,7 +625,14 @@ export function validateFieldValue(
       }
     ).safeParse(value);
     if (!result.success && result.error) {
-      const messages = result.error.issues.map((i) => i.message);
+      const messages = result.error.issues.map((issue) => {
+        const issuePath = issue.path.reduce(
+          (path, segment) =>
+            typeof segment === 'number' ? `${path}[${segment}]` : `${path}.${segment}`,
+          fieldPath,
+        );
+        return `${issuePath}: ${issue.message}`;
+      });
       return { success: false, error: messages.join('; ') || 'Validation failed' };
     }
   }
@@ -1102,7 +1109,7 @@ export const saveBaseConfigFn = createServerFn({ method: 'POST' })
       }
     }
     if (errors.length > 0) {
-      const details = errors.map((e) => `${e.fieldPath}: ${e.error}`).join('; ');
+      const details = errors.map((e) => e.error).join('; ');
       throw new Error(`Validation failed — ${details}`);
     }
 


### PR DESCRIPTION
## Summary

Config field validation currently drops nested Zod issue paths, so failures inside objects and arrays only identify the top-level field. This makes it difficult to locate the specific invalid value.

This PR preserves each issue path when formatting validation errors. A missing nested field now reports its array index and property path, while top-level validation messages retain their existing format.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added regression coverage for a missing required field inside a custom-endpoint array entry.

- `bun run test src/server/config.test.ts` (497 tests passed)
- `bunx eslint src/server/config.ts src/server/config.test.ts`
- `bunx prettier --check src/server/config.ts src/server/config.test.ts`

### **Test Configuration**:

- Bun 1.3.3

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
